### PR TITLE
Elasticsearch 7 and association preloading

### DIFF
--- a/lib/scrivener/paginater/esx/search.ex
+++ b/lib/scrivener/paginater/esx/search.ex
@@ -4,13 +4,17 @@ defimpl Scrivener.Paginater, for: ESx.Model.Search do
   @moduledoc false
 
   @spec paginate(ESx.Model.Search.t, Scrivener.Config.t) :: Scrivener.Page.t
-  def paginate(search, %Config{page_size: page_size, page_number: page_number, module: model}) do
-    model = Map.get search, :__model__, model
+  def paginate(search, %Config{page_size: page_size, page_number: page_number, module: model} = config) do
+    model = Map.get(search, :__model__, model)
+    opts = Map.get(config, :options, [])
     search = pager_condition(search, page_number, page_size)
+
+    schema = Map.fetch(search, :__schema__)
+    queryable = Keyword.get(opts, :queryable, schema)
 
     {entries, total_entries} =
       if model.repo do
-        rsp = model.records search
+        rsp = model.records search, queryable
         {rsp.records, rsp.total["value"]}
       else
         rsp = model.results search

--- a/lib/scrivener/paginater/esx/search.ex
+++ b/lib/scrivener/paginater/esx/search.ex
@@ -9,7 +9,7 @@ defimpl Scrivener.Paginater, for: ESx.Model.Search do
     opts = Map.get(config, :options, [])
     search = pager_condition(search, page_number, page_size)
 
-    schema = Map.fetch(search, :__schema__)
+    schema = Map.get(search, :__schema__)
     queryable = Keyword.get(opts, :queryable, schema)
 
     {entries, total_entries} =

--- a/lib/scrivener/paginater/esx/search.ex
+++ b/lib/scrivener/paginater/esx/search.ex
@@ -11,7 +11,7 @@ defimpl Scrivener.Paginater, for: ESx.Model.Search do
     {entries, total_entries} =
       if model.repo do
         rsp = model.records search
-        {rsp.records, rsp.total}
+        {rsp.records, rsp.total["value"]}
       else
         rsp = model.results search
         {rsp.hits, rsp.total["value"]}

--- a/lib/scrivener/paginater/esx/search.ex
+++ b/lib/scrivener/paginater/esx/search.ex
@@ -14,7 +14,7 @@ defimpl Scrivener.Paginater, for: ESx.Model.Search do
         {rsp.records, rsp.total}
       else
         rsp = model.results search
-        {rsp.hits, rsp.total}
+        {rsp.hits, rsp.total["value"]}
       end
 
     %Page{


### PR DESCRIPTION
1. Adds (breaking) support for Elasticsearch 7, which has changed the way that [total hits are returned](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-track-total-hits.html)
2. Allows associations to be preloaded by the paginate method, like so:
```elixir
  def index(conn, params) do
    query = %{query: %{match_all: %{}}, sort: %{created_at: :desc}}
    opts = %{options: [queryable: from(i in Image, preload: :user)]}

    images = ESx.search(Image, query) |> ESx.paginate(Map.merge(params, opts))

    render conn, "index.html", images: images.entries
  end
```